### PR TITLE
Add CITATION.cff

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,38 @@
+# This CITATION.cff file was generated with cffinit.
+# Visit https://bit.ly/cffinit to generate yours today!
+
+cff-version: 1.2.0
+title: DOpELib
+message: >-
+  If you use this software, please cite the overview paper
+  (preferred citation).
+type: software
+authors:
+  - family-names: "Goll"
+    given-names: "Christian"
+  - family-names: "Wick"
+    given-names: "Thomas"
+  - family-names: "Wollner"
+    given-names: "Winnifried"
+identifiers:
+  - type: url
+    value: 'www.dopelib.net'
+repository-code: 'https://github.com/winnifried/dopelib'
+license: LGPL-2.1-or-later
+preferred-citation:
+  type: article
+  authors:
+  - family-names: "Goll"
+    given-names: "Christian"
+  - family-names: "Wick"
+    given-names: "Thomas"
+  - family-names: "Wollner"
+    given-names: "Winnifried"
+  doi: "10.11588/ans.2017.2.11815"
+  journal: "Archive of Numerical Software"
+  month: 7
+  start: 1
+  end: 14
+  title: "DOpElib: Differential Equations and Optimization Environment; A Goal Oriented Software Library for Solving PDEs and Optimization Problems with PDEs"
+  volume: 5
+  year: 2017


### PR DESCRIPTION
This adds a file in Citation File Format to help users wanting to cite DOpElib.
When added, an entry is added on the repository main page titled
`cite this repository` and will directly provide APA and BIB entries 
of the DOpElib ANS publication.